### PR TITLE
Content type fix

### DIFF
--- a/lib/rack/jsonp.rb
+++ b/lib/rack/jsonp.rb
@@ -25,10 +25,16 @@ module Rack
         body.each { |s| json << s }
         body = ["#{callback}(#{json});"]
         headers['Content-Length'] = Rack::Utils.bytesize(body[0]).to_s
-        headers['Content-Type'] = 'application/javascript'
+        headers['Content-Type'] = force_mime_type(headers['Content-Type'], 'application/javascript')
       end
 
       [status, headers, body]
+    end
+
+    def force_mime_type(content_type, mime_type)
+      content_type_parts = (content_type || '').split(/;/)
+      content_type_parts[0] = mime_type
+      content_type_parts.join(';')
     end
 
   end

--- a/lib/rack/jsonp.rb
+++ b/lib/rack/jsonp.rb
@@ -17,7 +17,7 @@ module Rack
         env['PATH_INFO'].sub!(/\.jsonp/i, '.json')
         env['REQUEST_URI'] = env['PATH_INFO']
       end
-      
+
       status, headers, body = @app.call(env)
 
       if requesting_jsonp && headers['Content-Type'] && headers['Content-Type'].match(/application\/json/i)

--- a/lib/rack/jsonp.rb
+++ b/lib/rack/jsonp.rb
@@ -24,7 +24,7 @@ module Rack
         json = ""
         body.each { |s| json << s }
         body = ["#{callback}(#{json});"]
-        headers['Content-Length'] = body[0].length.to_s
+        headers['Content-Length'] = Rack::Utils.bytesize(body[0]).to_s
         headers['Content-Type'] = 'application/javascript'
       end
 

--- a/spec/jsonp_spec.rb
+++ b/spec/jsonp_spec.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 require 'spec_helper.rb'
 
 describe Rack::JSONP do
@@ -42,6 +44,34 @@ describe Rack::JSONP do
     end
 
   end
+
+  describe 'when a valid jsonp request is made with multibyte characters' do
+
+    before :each do
+      @response_body = ['{"key":"√alue"}']
+      @request = Rack::MockRequest.env_for("/action.jsonp?callback=#{@callback}")
+      @jsonp_response = Rack::JSONP.new(@app).call(@request)
+      @jsonp_response_status, @jsonp_response_headers, @jsonp_response_body = @jsonp_response
+    end
+
+    it 'should not modify the response status code' do
+      @jsonp_response_status.should equal @response_status
+    end
+
+    it 'should update the response content length to the new value' do
+      @jsonp_response_headers['Content-Length'].should == '34'
+    end
+
+    it 'should set the response content type as application/javascript' do
+      @jsonp_response_headers['Content-Type'].should == 'application/javascript'
+    end
+
+    it 'should wrap the response body in the Javasript callback' do
+      @jsonp_response_body.should == ["#{@callback}(#{@response_body.first});"]
+    end
+
+  end
+
 
   describe 'when a jsonp request is made wihtout a callback parameter present' do
 

--- a/spec/jsonp_spec.rb
+++ b/spec/jsonp_spec.rb
@@ -48,6 +48,7 @@ describe Rack::JSONP do
   describe 'when a valid jsonp request is made with multibyte characters' do
 
     before :each do
+      @response_headers['Content-Type'] = 'application/json; charset=utf-8'
       @response_body = ['{"key":"√alue"}']
       @request = Rack::MockRequest.env_for("/action.jsonp?callback=#{@callback}")
       @jsonp_response = Rack::JSONP.new(@app).call(@request)
@@ -62,8 +63,8 @@ describe Rack::JSONP do
       @jsonp_response_headers['Content-Length'].should == '34'
     end
 
-    it 'should set the response content type as application/javascript' do
-      @jsonp_response_headers['Content-Type'].should == 'application/javascript'
+    it 'should set the response content type as application/javascript without munging the charset' do
+      @jsonp_response_headers['Content-Type'].should == 'application/javascript; charset=utf-8'
     end
 
     it 'should wrap the response body in the Javasript callback' do

--- a/spec/jsonp_spec.rb
+++ b/spec/jsonp_spec.rb
@@ -2,10 +2,10 @@ require 'spec_helper.rb'
 
 describe Rack::JSONP do
 
-  before :each do 
+  before :each do
     @response_status = 200
     @response_headers = {
-     'Content-Type' => 'application/json', 
+     'Content-Type' => 'application/json',
      'Content-Length' => '15',
     }
     @response_body = ['{"key":"value"}']
@@ -13,12 +13,12 @@ describe Rack::JSONP do
     @app = lambda do |params|
       [@response_status, @response_headers, @response_body]
     end
-    
+
     @callback = 'J50Npi.success'
   end
-  
+
   describe 'when a valid jsonp request is made' do
-   
+
     before :each do
       @request = Rack::MockRequest.env_for("/action.jsonp?callback=#{@callback}")
       @jsonp_response = Rack::JSONP.new(@app).call(@request)
@@ -44,7 +44,7 @@ describe Rack::JSONP do
   end
 
   describe 'when a jsonp request is made wihtout a callback parameter present' do
-  
+
     before :each do
       @request = Rack::MockRequest.env_for('/action.jsonp')
       @jsonp_response = Rack::JSONP.new(@app).call(@request)
@@ -56,17 +56,17 @@ describe Rack::JSONP do
     end
 
     it 'should return an empty body' do
-      @jsonp_response_body.should == []      
-    end    
+      @jsonp_response_body.should == []
+    end
 
     it 'should return empty headers' do
-      @jsonp_response_headers.should == {}     
-    end 
+      @jsonp_response_headers.should == {}
+    end
 
   end
 
   describe 'when a non jsonp request is made' do
-    
+
     before :each do
       @request = Rack::MockRequest.env_for('/action.json')
       @jsonp_response = Rack::JSONP.new(@app).call(@request)
@@ -105,7 +105,7 @@ describe Rack::JSONP do
     it 'should not modify the response body' do
       @jsonp_response_body.should == @response_body
     end
-    
+
     it 'should not odify the headers Content-Type' do
       @jsonp_response_headers['Content-Type'].should == @response_headers['Content-Type']
     end


### PR DESCRIPTION
**NOTE:** This pull request depends on #3 (and/or includes #3)...
## Background

rack-jsonp-middleware forces the response `Content-Type` header to be:

`Content-Type: application/javascript`

The idea was to change:

``` diff
- Content-Type: application/json
+ Content-Type: application/javascript
```

However, if the previous `Content-Type` had the `charset` suffix, then it would be overwritten like so:

``` diff
- Content-Type: application/json; charset=utf-8
+ Content-Type: application/javascript
```
## This pull request fixes that

It works by splitting on `;` and only altering the first part.

Cheers :beers:
