### PR TITLE
Add support for using format=jsonp in the query string

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,15 @@
 PATH
   remote: .
   specs:
-    rack-jsonp-middleware (0.0.5)
+    rack-jsonp-middleware (0.0.7)
       rack
 
 GEM
   remote: http://rubygems.org/
   specs:
     diff-lcs (1.1.2)
-    rack (1.2.1)
+    rack (1.4.1)
+    rake (10.0.0)
     rspec (2.5.0)
       rspec-core (~> 2.5.0)
       rspec-expectations (~> 2.5.0)
@@ -23,4 +24,5 @@ PLATFORMS
 
 DEPENDENCIES
   rack-jsonp-middleware!
+  rake
   rspec (>= 1.3.0)

--- a/lib/rack/jsonp.rb
+++ b/lib/rack/jsonp.rb
@@ -11,7 +11,7 @@ module Rack
 
     def call(env)
       request = Rack::Request.new(env)
-      requesting_jsonp = Pathname(request.env['PATH_INFO']).extname =~ /^\.jsonp$/i
+      requesting_jsonp = ( Pathname(request.env['PATH_INFO']).extname =~ /^\.jsonp$/i || request.params['format'] == 'jsonp')
       callback = request.params['callback']
 
       return [400,{},[]] if requesting_jsonp && !self.valid_callback?(callback)

--- a/spec/jsonp_spec.rb
+++ b/spec/jsonp_spec.rb
@@ -44,6 +44,30 @@ describe Rack::JSONP do
     end
 
   end
+  
+  describe 'using format attribute instead of path extension' do
+    before :each do
+      @request = Rack::MockRequest.env_for("/action?callback=#{@callback}&format=jsonp")
+      @jsonp_response = Rack::JSONP.new(@app).call(@request)
+      @jsonp_response_status, @jsonp_response_headers, @jsonp_response_body = @jsonp_response
+    end
+    
+    it 'should not modify the response status code' do
+      @jsonp_response_status.should == @response_status
+    end
+
+    it 'should update the response content length to the new value' do
+      @jsonp_response_headers['Content-Length'].should == '32'
+    end
+
+    it 'should set the response content type as application/javascript' do
+      @jsonp_response_headers['Content-Type'].should == 'application/javascript'
+    end
+
+    it 'should wrap the response body in the Javasript callback' do
+      @jsonp_response_body.should == ["#{@callback}(#{@response_body.first});"]
+    end
+  end
 
   describe 'when a valid jsonp request is made with multibyte characters' do
 


### PR DESCRIPTION
This is a very rails specific change, but format=jsonp is the same as appending .jsonp to the path.
