### PR TITLE
Prevent Rosetta Flash attack

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       rack
 
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     colorize (0.5.8)
     coveralls (0.6.5)

--- a/lib/rack/jsonp.rb
+++ b/lib/rack/jsonp.rb
@@ -26,7 +26,7 @@ module Rack
       if requesting_jsonp && self.json_response?(headers['Content-Type'])
         json = ""
         body.each { |s| json << s }
-        body = ["#{callback}(#{json});"]
+        body = ["/**/#{callback}(#{json});"]
         headers['Content-Length'] = Rack::Utils.bytesize(body[0]).to_s
         headers['Content-Type'] = headers['Content-Type'].sub(/^[^;]+(;?)/, "#{MIME_TYPE}\\1")
       end

--- a/spec/jsonp_spec.rb
+++ b/spec/jsonp_spec.rb
@@ -32,7 +32,7 @@ describe Rack::JSONP do
     end
 
     it 'should update the response content length to the new value' do
-      @jsonp_response_headers['Content-Length'].should == '32'
+      @jsonp_response_headers['Content-Length'].should == '36'
     end
 
     it 'should set the response content type as application/javascript' do
@@ -60,7 +60,7 @@ describe Rack::JSONP do
     end
 
     it 'should update the response content length to the new value' do
-      @jsonp_response_headers['Content-Length'].should == '34'
+      @jsonp_response_headers['Content-Length'].should == '38'
     end
 
     it 'should set the response content type as application/javascript without munging the charset' do

--- a/spec/jsonp_spec.rb
+++ b/spec/jsonp_spec.rb
@@ -40,7 +40,7 @@ describe Rack::JSONP do
     end
 
     it 'should wrap the response body in the Javasript callback' do
-      @jsonp_response_body.should == ["#{@callback}(#{@response_body.first});"]
+      @jsonp_response_body.should == ["/**/#{@callback}(#{@response_body.first});"]
     end
 
   end
@@ -68,7 +68,7 @@ describe Rack::JSONP do
     end
 
     it 'should wrap the response body in the Javasript callback' do
-      @jsonp_response_body.should == ["#{@callback}(#{@response_body.first});"]
+      @jsonp_response_body.should == ["/**/#{@callback}(#{@response_body.first});"]
     end
 
   end


### PR DESCRIPTION
Refer to http://miki.it/blog/2014/7/8/abusing-jsonp-with-rosetta-flash/ for a description of the vulnerability. This simple patch prevents the attack from working.
